### PR TITLE
force ssh-keygen to generate private key in PEM format

### DIFF
--- a/ipavagrant/ipaci.py
+++ b/ipavagrant/ipaci.py
@@ -50,6 +50,7 @@ class IPACITopology(VagrantCtl):
         command = [
             "ssh-keygen",
             "-f", str(os.path.join(self.path, constants.CONTROLLER_SSH_KEY)),
+            "-m", "PEM",
             "-P", "",
         ]
         logging.debug("Generate SSH keys for '%s' topology",


### PR DESCRIPTION
Default key format have changed in Fedora 28 and new format is not supportred by paramiko

paramiko ecpects key header to be
```
-----BEGIN RSA PRIVATE KEY-----
```
ssh-keygen from Fedora 28 by default produces 
```
-----BEGIN OPENSSH PRIVATE KEY-----
```

Option `-m PEM` produces key with old format. It is undocumented for making new key (only for import and export) but works at least in Fedora 27 and 28 